### PR TITLE
Fix typo in method name

### DIFF
--- a/app/server/chat.py
+++ b/app/server/chat.py
@@ -80,7 +80,7 @@ async def create_chat_completion(
         # Start a new session and concat messages into a single string
         session = client.start_chat(model=model)
         try:
-            model_input, files = await client.precess_conversation(request.messages, tmp_dir)
+            model_input, files = await client.process_conversation(request.messages, tmp_dir)
         except ValueError as e:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
         except Exception as e:

--- a/app/services/client.py
+++ b/app/services/client.py
@@ -68,10 +68,10 @@ class SingletonGeminiClient(GeminiClient, metaclass=Singleton):
         return model_input, files
 
     @staticmethod
-    async def precess_conversation(messages: list[Message], tempdir: Path | None = None):
+    async def process_conversation(messages: list[Message], tempdir: Path | None = None):
         """
-        Process the entire conversation and return a formatted string and list of files.
-        The last message is assumed to be the assistant's response.
+        Process the entire conversation and return a formatted string and list of
+        files. The last message is assumed to be the assistant's response.
         """
         conversation: list[str] = []
         files: list[Path | str] = []


### PR DESCRIPTION
## Summary
- fix method name `precess_conversation` -> `process_conversation`
- update usage in chat API

## Testing
- `ruff check`
- `ruff format --check`


------
https://chatgpt.com/codex/tasks/task_e_68583a339ab8832bbd93ac8e8d06dfd9