### PR TITLE
Fix LMDB history mismatch

### DIFF
--- a/app/server/chat.py
+++ b/app/server/chat.py
@@ -98,10 +98,11 @@ async def create_chat_completion(
 
     # Format and clean the output
     model_output = client.extract_output(response)
+    stored_output = client.extract_output(response, include_thoughts=False)
 
     # After cleaning, persist the conversation
     try:
-        last_message = Message(role="assistant", content=model_output)
+        last_message = Message(role="assistant", content=stored_output)
         conv = ConversationInStore(
             model=model.model_name,
             metadata=session.metadata,

--- a/app/services/client.py
+++ b/app/services/client.py
@@ -87,13 +87,13 @@ class SingletonGeminiClient(GeminiClient, metaclass=Singleton):
         return "\n".join(conversation), files
 
     @staticmethod
-    def extract_output(response: ModelOutput):
+    def extract_output(response: ModelOutput, include_thoughts: bool = True):
         """
         Extract and format the output text from the Gemini response.
         """
         text = ""
 
-        if response.thoughts:
+        if include_thoughts and response.thoughts:
             text += f"<think>{response.thoughts}</think>"
 
         if response.text:


### PR DESCRIPTION
## Summary
- make `extract_output` optionally include `<think>` sections
- store cleaned assistant replies without thoughts

## Testing
- `ruff format`
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_685945e45018832b9c05279c21e3ddb5