### PR TITLE
Implement Gemini client pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ pip install -e .
 
 ### Configuration
 
-Edit `config/config.yaml` and set your Gemini credentials:
+Edit `config/config.yaml` and provide at least one credential pair:
 ```yaml
 gemini:
-  secure_1psid: "YOUR_SECURE_1PSID_HERE"
-  secure_1psidts: "YOUR_SECURE_1PSIDTS_HERE"
+  clients:
+    - id: "client-a"
+      secure_1psid: "YOUR_SECURE_1PSID_HERE"
+      secure_1psidts: "YOUR_SECURE_1PSIDTS_HERE"
 ```
 
 > [!NOTE]
@@ -79,8 +81,9 @@ docker run -p 8000:8000 \
   -v $(pwd)/config:/app/config \
   -v $(pwd)/data:/app/data \
   -e CONFIG_SERVER__API_KEY="your-api-key-here" \
-  -e CONFIG_GEMINI__SECURE_1PSID="your-secure-1psid" \
-  -e CONFIG_GEMINI__SECURE_1PSIDTS="your-secure-1psidts" \
+  -e CONFIG_GEMINI__CLIENTS__0__ID="client-a" \
+  -e CONFIG_GEMINI__CLIENTS__0__SECURE_1PSID="your-secure-1psid" \
+  -e CONFIG_GEMINI__CLIENTS__0__SECURE_1PSIDTS="your-secure-1psidts" \
   ghcr.io/nativu5/gemini-fastapi
 ```
 
@@ -102,8 +105,9 @@ services:
       - CONFIG_SERVER__HOST=0.0.0.0
       - CONFIG_SERVER__PORT=8000
       - CONFIG_SERVER__API_KEY=${API_KEY}
-      - CONFIG_GEMINI__SECURE_1PSID=${SECURE_1PSID}
-      - CONFIG_GEMINI__SECURE_1PSIDTS=${SECURE_1PSIDTS}
+      - CONFIG_GEMINI__CLIENTS__0__ID=client-a
+      - CONFIG_GEMINI__CLIENTS__0__SECURE_1PSID=${SECURE_1PSID}
+      - CONFIG_GEMINI__CLIENTS__0__SECURE_1PSIDTS=${SECURE_1PSIDTS}
     restart: on-failure:3 # Avoid retrying too many times
 ```
 
@@ -134,13 +138,23 @@ You can override any configuration option using environment variables with the `
 # Override server settings
 export CONFIG_SERVER__API_KEY="your-secure-api-key"
 
-# Override Gemini credentials
-export CONFIG_GEMINI__SECURE_1PSID="your-secure-1psid"
-export CONFIG_GEMINI__SECURE_1PSIDTS="your-secure-1psidts"
+# Override Gemini credentials (first client)
+export CONFIG_GEMINI__CLIENTS__0__ID="client-a"
+export CONFIG_GEMINI__CLIENTS__0__SECURE_1PSID="your-secure-1psid"
+export CONFIG_GEMINI__CLIENTS__0__SECURE_1PSIDTS="your-secure-1psidts"
+
+# You can also override the entire list using JSON
+# export CONFIG_GEMINI__CLIENTS='[{"id":"client-a","secure_1psid":"psid","secure_1psidts":"psidts"}]'
 
 # Override conversation storage size limit
 export CONFIG_STORAGE__MAX_SIZE=268435456  # 256 MB
 ```
+
+### Client IDs and Conversation Reuse
+
+Conversations are stored with the ID of the client that generated them.
+Keep these identifiers stable in your configuration so that sessions remain valid
+when you update the cookie list.
 
 ### Gemini Credentials
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -49,11 +49,13 @@ pip install -e .
 
 ### 配置
 
-编辑 `config/config.yaml` 并填写 Gemini 凭证：
+编辑 `config/config.yaml` 并提供至少一组凭证：
 ```yaml
 gemini:
-  secure_1psid: "YOUR_SECURE_1PSID_HERE"
-  secure_1psidts: "YOUR_SECURE_1PSIDTS_HERE"
+  clients:
+    - id: "client-a"
+      secure_1psid: "YOUR_SECURE_1PSID_HERE"
+      secure_1psidts: "YOUR_SECURE_1PSIDTS_HERE"
 ```
 
 > [!NOTE]
@@ -80,8 +82,9 @@ docker run -p 8000:8000 \
   -v $(pwd)/config:/app/config \
   -v $(pwd)/data:/app/data \
   -e CONFIG_SERVER__API_KEY="your-api-key-here" \
-  -e CONFIG_GEMINI__SECURE_1PSID="your-secure-1psid" \
-  -e CONFIG_GEMINI__SECURE_1PSIDTS="your-secure-1psidts" \
+  -e CONFIG_GEMINI__CLIENTS__0__ID="client-a" \
+  -e CONFIG_GEMINI__CLIENTS__0__SECURE_1PSID="your-secure-1psid" \
+  -e CONFIG_GEMINI__CLIENTS__0__SECURE_1PSIDTS="your-secure-1psidts" \
   ghcr.io/nativu5/gemini-fastapi
 ```
 
@@ -103,8 +106,9 @@ services:
       - CONFIG_SERVER__HOST=0.0.0.0
       - CONFIG_SERVER__PORT=8000
       - CONFIG_SERVER__API_KEY=${API_KEY}
-      - CONFIG_GEMINI__SECURE_1PSID=${SECURE_1PSID}
-      - CONFIG_GEMINI__SECURE_1PSIDTS=${SECURE_1PSIDTS}
+      - CONFIG_GEMINI__CLIENTS__0__ID=client-a
+      - CONFIG_GEMINI__CLIENTS__0__SECURE_1PSID=${SECURE_1PSID}
+      - CONFIG_GEMINI__CLIENTS__0__SECURE_1PSIDTS=${SECURE_1PSIDTS}
     restart: on-failure:3 # 避免过多重试
 ```
 
@@ -136,12 +140,21 @@ docker compose up -d
 export CONFIG_SERVER__API_KEY="your-secure-api-key"
 
 # 覆盖 Gemini Cookie
-export CONFIG_GEMINI__SECURE_1PSID="your-secure-1psid"
-export CONFIG_GEMINI__SECURE_1PSIDTS="your-secure-1psidts"
+export CONFIG_GEMINI__CLIENTS__0__ID="client-a"
+export CONFIG_GEMINI__CLIENTS__0__SECURE_1PSID="your-secure-1psid"
+export CONFIG_GEMINI__CLIENTS__0__SECURE_1PSIDTS="your-secure-1psidts"
+
+# 也可以使用 JSON 覆盖整个列表
+# export CONFIG_GEMINI__CLIENTS='[{"id":"client-a","secure_1psid":"psid","secure_1psidts":"psidts"}]'
 
 # 覆盖对话存储大小限制
 export CONFIG_STORAGE__MAX_SIZE=268435456  # 256 MB
 ```
+
+### 客户端 ID 与会话重用
+
+会话在保存时会绑定创建它的客户端 ID。请在配置中保持这些 `id` 值稳定，
+这样在更新 Cookie 列表时依然可以复用旧会话。
 
 ### Gemini 凭据
 

--- a/app/main.py
+++ b/app/main.py
@@ -6,19 +6,19 @@ from loguru import logger
 from .server.chat import router as chat_router
 from .server.health import router as health_router
 from .server.middleware import add_cors_middleware, add_exception_handler
-from .services.client import SingletonGeminiClient
+from .services.pool import GeminiClientPool
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     try:
-        client = SingletonGeminiClient()
-        await client.init()
+        pool = GeminiClientPool()
+        await pool.init()
     except Exception as e:
-        logger.exception(f"Failed to initialize Gemini client: {e}")
+        logger.exception(f"Failed to initialize Gemini clients: {e}")
         raise
 
-    logger.info("Gemini client initialized on server startup.")
+    logger.info("Gemini clients initialized on server startup.")
     logger.info("Gemini API Server ready to serve requests.")
     yield
 

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -84,6 +84,7 @@ class HealthCheckResponse(BaseModel):
 
     ok: bool
     storage: Optional[Dict[str, str | int]] = None
+    clients: Optional[Dict[str, bool]] = None
     error: Optional[str] = None
 
 
@@ -95,6 +96,7 @@ class ConversationInStore(BaseModel):
 
     # NOTE: Gemini Web API do not support changing models once a conversation is created.
     model: str = Field(..., description="Model used for the conversation")
+    client_id: str = Field(..., description="Identifier of the Gemini client")
     metadata: list[str | None] = Field(
         ..., description="Metadata for Gemini API to locate the conversation"
     )

--- a/app/server/chat.py
+++ b/app/server/chat.py
@@ -15,7 +15,11 @@ from ..models import (
     ModelData,
     ModelListResponse,
 )
-from ..services import LMDBConversationStore, SingletonGeminiClient
+from ..services import (
+    GeminiClientPool,
+    GeminiClientWrapper,
+    LMDBConversationStore,
+)
 from ..utils.helper import estimate_tokens
 from .middleware import get_temp_dir, verify_api_key
 
@@ -49,7 +53,7 @@ async def create_chat_completion(
     api_key: str = Depends(verify_api_key),
     tmp_dir: Path = Depends(get_temp_dir),
 ):
-    client = SingletonGeminiClient()
+    pool = GeminiClientPool()
     db = LMDBConversationStore()
     model = Model.from_name(request.model)
 
@@ -61,10 +65,12 @@ async def create_chat_completion(
 
     # Check if conversation is reusable
     session = None
+    client = None
     if _check_reusable(request.messages):
         try:
             # Exclude the last message from user
             if old_conv := db.find(model.model_name, request.messages[:-1]):
+                client = pool.acquire(old_conv.client_id)
                 session = client.start_chat(metadata=old_conv.metadata, model=model)
         except Exception as e:
             session = None
@@ -72,15 +78,18 @@ async def create_chat_completion(
 
     if session:
         # Just send the last message to the existing session
-        model_input, files = await client.process_message(
+        model_input, files = await GeminiClientWrapper.process_message(
             request.messages[-1], tmp_dir, tagged=False
         )
         logger.debug(f"Found reusable session: {session.metadata}")
     else:
         # Start a new session and concat messages into a single string
+        client = pool.acquire()
         session = client.start_chat(model=model)
         try:
-            model_input, files = await client.process_conversation(request.messages, tmp_dir)
+            model_input, files = await GeminiClientWrapper.process_conversation(
+                request.messages, tmp_dir
+            )
         except ValueError as e:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
         except Exception as e:
@@ -97,14 +106,15 @@ async def create_chat_completion(
         raise
 
     # Format and clean the output
-    model_output = client.extract_output(response)
-    stored_output = client.extract_output(response, include_thoughts=False)
+    model_output = GeminiClientWrapper.extract_output(response)
+    stored_output = GeminiClientWrapper.extract_output(response, include_thoughts=False)
 
     # After cleaning, persist the conversation
     try:
         last_message = Message(role="assistant", content=stored_output)
         conv = ConversationInStore(
             model=model.model_name,
+            client_id=client.id,
             metadata=session.metadata,
             messages=[*request.messages, last_message],
         )

--- a/app/server/health.py
+++ b/app/server/health.py
@@ -2,26 +2,32 @@ from fastapi import APIRouter
 from loguru import logger
 
 from ..models import HealthCheckResponse
-from ..services import LMDBConversationStore, SingletonGeminiClient
+from ..services import GeminiClientPool, LMDBConversationStore
 
 router = APIRouter()
 
 
 @router.get("/health", response_model=HealthCheckResponse)
 async def health_check():
-    client = SingletonGeminiClient()
+    pool = GeminiClientPool()
     db = LMDBConversationStore()
 
-    if not client.running:
-        try:
-            await client.init()
-        except Exception as e:
-            logger.error(f"Failed to initialize Gemini client: {e}")
-            return HealthCheckResponse(ok=False, error=str(e))
+    try:
+        await pool.init()
+    except Exception as e:
+        logger.error(f"Failed to initialize Gemini clients: {e}")
+        return HealthCheckResponse(ok=False, error=str(e))
+
+    client_status = pool.status()
+
+    if not all(client_status.values()):
+        logger.warning("One or more Gemini clients not running")
 
     stat = db.stats()
     if not stat:
         logger.error("Failed to retrieve LMDB conversation store stats")
-        return HealthCheckResponse(ok=False, error="LMDB conversation store unavailable")
+        return HealthCheckResponse(
+            ok=False, error="LMDB conversation store unavailable", clients=client_status
+        )
 
-    return HealthCheckResponse(ok=True, storage=stat)
+    return HealthCheckResponse(ok=all(client_status.values()), storage=stat, clients=client_status)

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,7 +1,9 @@
-from .client import SingletonGeminiClient
+from .client import GeminiClientWrapper
 from .lmdb import LMDBConversationStore
+from .pool import GeminiClientPool
 
 __all__ = [
+    "GeminiClientPool",
+    "GeminiClientWrapper",
     "LMDBConversationStore",
-    "SingletonGeminiClient",
 ]

--- a/app/services/client.py
+++ b/app/services/client.py
@@ -6,15 +6,14 @@ from gemini_webapi import GeminiClient, ModelOutput
 from ..models import Message
 from ..utils import g_config
 from ..utils.helper import add_tag, save_file_to_tempfile, save_url_to_tempfile
-from ..utils.singleton import Singleton
 
 
-class SingletonGeminiClient(GeminiClient, metaclass=Singleton):
-    def __init__(self, **kwargs):
-        kwargs.setdefault("secure_1psid", g_config.gemini.secure_1psid)
-        kwargs.setdefault("secure_1psidts", g_config.gemini.secure_1psidts)
+class GeminiClientWrapper(GeminiClient):
+    """Gemini client with helper methods."""
 
+    def __init__(self, client_id: str, **kwargs):
         super().__init__(**kwargs)
+        self.id = client_id
 
     async def init(self, **kwargs):
         # Inject default configuration values
@@ -77,7 +76,7 @@ class SingletonGeminiClient(GeminiClient, metaclass=Singleton):
         files: list[Path | str] = []
 
         for msg in messages:
-            input_part, files_part = await SingletonGeminiClient.process_message(msg, tempdir)
+            input_part, files_part = await GeminiClientWrapper.process_message(msg, tempdir)
             conversation.append(input_part)
             files.extend(files_part)
 

--- a/app/services/lmdb.py
+++ b/app/services/lmdb.py
@@ -21,10 +21,11 @@ def hash_message(message: Message) -> str:
     return hashlib.sha256(message_bytes).hexdigest()
 
 
-def hash_conversation(model: str, messages: List[Message]) -> str:
-    """Generate a hash for a list of messages."""
+def hash_conversation(client_id: str, model: str, messages: List[Message]) -> str:
+    """Generate a hash for a list of messages and client id."""
     # Create a combined hash from all individual message hashes
     combined_hash = hashlib.sha256()
+    combined_hash.update(client_id.encode("utf-8"))
     combined_hash.update(model.encode("utf-8"))
     for message in messages:
         message_hash = hash_message(message)
@@ -35,7 +36,7 @@ def hash_conversation(model: str, messages: List[Message]) -> str:
 class LMDBConversationStore(metaclass=Singleton):
     """LMDB-based storage for Message lists with hash-based key-value operations."""
 
-    CUSTOM_KEY_BINDING_PREFIX = "hash:"
+    HASH_LOOKUP_PREFIX = "hash:"
 
     def __init__(self, db_path: Optional[str] = None, max_db_size: Optional[int] = None):
         """
@@ -115,7 +116,7 @@ class LMDBConversationStore(metaclass=Singleton):
             raise ValueError("Messages list cannot be empty")
 
         # Generate hash for the message list
-        message_hash = hash_conversation(conv.model, conv.messages)
+        message_hash = hash_conversation(conv.client_id, conv.model, conv.messages)
         storage_key = custom_key or message_hash
 
         # Prepare data for storage
@@ -132,11 +133,10 @@ class LMDBConversationStore(metaclass=Singleton):
                 txn.put(storage_key.encode("utf-8"), value, overwrite=True)
 
                 # Store hash -> key mapping for reverse lookup
-                if custom_key:
-                    txn.put(
-                        f"{self.CUSTOM_KEY_BINDING_PREFIX}{message_hash}".encode("utf-8"),
-                        custom_key.encode("utf-8"),
-                    )
+                txn.put(
+                    f"{self.HASH_LOOKUP_PREFIX}{message_hash}".encode("utf-8"),
+                    storage_key.encode("utf-8"),
+                )
 
                 logger.debug(f"Stored {len(conv.messages)} messages with key: {storage_key}")
                 return storage_key
@@ -185,21 +185,21 @@ class LMDBConversationStore(metaclass=Singleton):
         if not messages:
             return None
 
-        message_hash = hash_conversation(model, messages)
-        key = f"{self.CUSTOM_KEY_BINDING_PREFIX}{message_hash}"
+        for c in g_config.gemini.clients:
+            message_hash = hash_conversation(c.id, model, messages)
+            key = f"{self.HASH_LOOKUP_PREFIX}{message_hash}"
+            try:
+                with self._get_transaction(write=False) as txn:
+                    mapped = txn.get(key.encode("utf-8"))
+                    if mapped:
+                        return self.get(mapped.decode("utf-8"))
+            except Exception as e:
+                logger.error(f"Failed to retrieve messages by message list: {e}")
+                return None
 
-        try:
-            with self._get_transaction(write=False) as txn:
-                # Try custom key binding first
-                key = txn.get(key.encode("utf-8"), default=None)
-                key = key.decode("utf-8") if key else message_hash  # type: ignore
-
-                # Fallback to hash if no custom key found
-                return self.get(key)
-
-        except Exception as e:
-            logger.error(f"Failed to retrieve messages by message list: {e}")
-            return None
+            if conv := self.get(message_hash):
+                return conv
+        return None
 
     def exists(self, key: str) -> bool:
         """
@@ -237,14 +237,14 @@ class LMDBConversationStore(metaclass=Singleton):
 
                 storage_data = orjson.loads(data)  # type: ignore
                 conv = ConversationInStore.model_validate(storage_data)
-                message_hash = hash_conversation(conv.model, conv.messages)
+                message_hash = hash_conversation(conv.client_id, conv.model, conv.messages)
 
                 # Delete main data
                 txn.delete(key.encode("utf-8"))
 
                 # Clean up hash mapping if it exists
                 if message_hash and key != message_hash:
-                    txn.delete(f"{self.CUSTOM_KEY_BINDING_PREFIX}{message_hash}".encode("utf-8"))
+                    txn.delete(f"{self.HASH_LOOKUP_PREFIX}{message_hash}".encode("utf-8"))
 
                 logger.info(f"Deleted messages with key: {key}")
                 return conv
@@ -274,7 +274,7 @@ class LMDBConversationStore(metaclass=Singleton):
                 for key, _ in cursor:
                     key_str = key.decode("utf-8")
                     # Skip internal hash mappings
-                    if key_str.startswith(self.CUSTOM_KEY_BINDING_PREFIX):
+                    if key_str.startswith(self.HASH_LOOKUP_PREFIX):
                         continue
 
                     if not prefix or key_str.startswith(prefix):

--- a/app/services/pool.py
+++ b/app/services/pool.py
@@ -1,0 +1,56 @@
+from collections import deque
+from typing import Dict, List, Optional
+
+from ..utils import g_config
+from .client import GeminiClientWrapper
+
+
+class GeminiClientPool:
+    """Pool of GeminiClient instances identified by unique ids."""
+
+    def __init__(self) -> None:
+        self._clients: List[GeminiClientWrapper] = []
+        self._id_map: Dict[str, GeminiClientWrapper] = {}
+        self._round_robin = deque()
+
+        for c in g_config.gemini.clients:
+            client = GeminiClientWrapper(
+                client_id=c.id,
+                secure_1psid=c.secure_1psid,
+                secure_1psidts=c.secure_1psidts,
+            )
+            self._clients.append(client)
+            self._id_map[c.id] = client
+            self._round_robin.append(client)
+
+    async def init(self) -> None:
+        """Initialize all clients in the pool."""
+        for client in self._clients:
+            if not client.running:
+                await client.init(
+                    timeout=g_config.gemini.timeout,
+                    auto_refresh=g_config.gemini.auto_refresh,
+                    verbose=g_config.gemini.verbose,
+                    refresh_interval=g_config.gemini.refresh_interval,
+                )
+
+    def acquire(self, client_id: Optional[str] = None) -> GeminiClientWrapper:
+        """Return a client by id or using round-robin."""
+        if client_id:
+            client = self._id_map.get(client_id)
+            if not client:
+                raise ValueError(f"Client id {client_id} not found")
+            return client
+
+        client = self._round_robin[0]
+        self._round_robin.rotate(-1)
+        return client
+
+    @property
+    def clients(self) -> List[GeminiClientWrapper]:
+        """Return managed clients."""
+        return self._clients
+
+    def status(self) -> Dict[str, bool]:
+        """Return running status for each client."""
+        return {client.id: client.running for client in self._clients}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -13,8 +13,10 @@ cors:
   allow_headers: ["*"]
 
 gemini:
-  secure_1psid: "YOUR_SECURE_1PSID_HERE"       # Required: Gemini session cookie
-  secure_1psidts: "YOUR_SECURE_1PSIDTS_HERE"   # Required: Gemini timestamp cookie
+  clients:
+    - id: "client-a"
+      secure_1psid: "YOUR_SECURE_1PSID_HERE"
+      secure_1psidts: "YOUR_SECURE_1PSIDTS_HERE"
   timeout: 60              # Init timeout in seconds
   auto_refresh: true       # Auto-refresh session cookies
   refresh_interval: 540    # Refresh interval in seconds


### PR DESCRIPTION
## Summary
- support multiple Gemini clients in config
- add GeminiClientPool for load balancing
- attach client id when storing conversations
- acquire chat sessions from the pool
- update health check and startup logic
- document multi-client configuration
- clarify that client ids must remain stable
- fix env override for client list

## Testing
- `ruff check app`
- `ruff format app/main.py app/models/models.py app/server/chat.py app/server/health.py app/services/__init__.py app/services/client.py app/services/lmdb.py app/services/pool.py app/utils/config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68597d44ccec832ba2377ca95067eef1