### PR TITLE
docs: update compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./config:/app/config
+      # - ./config:/app/config  # Uncomment to use a custom config file
       - ./data:/app/data
       - ./cache:/app/.venv/lib/python3.12/site-packages/gemini_webapi/utils/temp
     environment:

--- a/README.zh.md
+++ b/README.zh.md
@@ -99,7 +99,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./config:/app/config
+      # - ./config:/app/config  # Uncomment to use a custom config file
       - ./data:/app/data
       - ./cache:/app/.venv/lib/python3.12/site-packages/gemini_webapi/utils/temp
     environment:


### PR DESCRIPTION
## Summary
- comment out default config volume in Docker Compose example

Commenting the config mount allows the image to start even if the default configuration file isn't cloned. Users can uncomment the line to supply a custom config.

## Testing
- `ruff format --check .`
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_685e62d9ea4c832ba194d2b77e8c90f3