### PR TITLE
docs: update compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ The server will start on `http://localhost:8000` by default.
 
 ```bash
 docker run -p 8000:8000 \
-  -v $(pwd)/config:/app/config \
   -v $(pwd)/data:/app/data \
+  -v $(pwd)/cache:/app/.venv/lib/python3.12/site-packages/gemini_webapi/utils/temp \
   -e CONFIG_SERVER__API_KEY="your-api-key-here" \
   -e CONFIG_GEMINI__CLIENTS__0__ID="client-a" \
   -e CONFIG_GEMINI__CLIENTS__0__SECURE_1PSID="your-secure-1psid" \
@@ -98,7 +98,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./config:/app/config
+      # - ./config:/app/config  # Uncomment to use a custom config file
       - ./data:/app/data
       - ./cache:/app/.venv/lib/python3.12/site-packages/gemini_webapi/utils/temp
     environment:

--- a/README.zh.md
+++ b/README.zh.md
@@ -79,8 +79,8 @@ python run.py
 
 ```bash
 docker run -p 8000:8000 \
-  -v $(pwd)/config:/app/config \
   -v $(pwd)/data:/app/data \
+  -v $(pwd)/cache:/app/.venv/lib/python3.12/site-packages/gemini_webapi/utils/temp \
   -e CONFIG_SERVER__API_KEY="your-api-key-here" \
   -e CONFIG_GEMINI__CLIENTS__0__ID="client-a" \
   -e CONFIG_GEMINI__CLIENTS__0__SECURE_1PSID="your-secure-1psid" \
@@ -99,7 +99,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./config:/app/config
+      # - ./config:/app/config  # Uncomment to use a custom config file
       - ./data:/app/data
       - ./cache:/app/.venv/lib/python3.12/site-packages/gemini_webapi/utils/temp
     environment:


### PR DESCRIPTION
## Summary
- comment out default config volume in Docker Compose example
- remove config mount from `docker run` and add cache mount

Commenting the config mount allows the image to start even if the default configuration file isn't cloned. Users can uncomment the line to supply a custom config.

## Testing
- `ruff format --check .`
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_685e62d9ea4c832ba194d2b77e8c90f3