### PR TITLE
:bug: Fix XML wrap hint formatting in client.py

### DIFF
--- a/app/services/client.py
+++ b/app/services/client.py
@@ -12,7 +12,7 @@ from ..models import Message
 from ..utils import g_config
 from ..utils.helper import add_tag, save_file_to_tempfile, save_url_to_tempfile
 
-XML_WRAP_HINT = "\nFor any xml block, e.g. tool call, always wrap it with:\n`````xml\n...\n`````\n"
+XML_WRAP_HINT = "\nFor any xml block, e.g. tool call, always wrap it with: \n`````xml\n...\n`````\n"
 
 
 class GeminiClientWrapper(GeminiClient):


### PR DESCRIPTION
3 个反引号是不够的，工具调用场景很容易出问题，比如代码块中还包含了代码块。 用更多反引号可以避免嵌套代码块渲染错误。