### PR TITLE
:white_check_mark: Add Ruff lint workflow triggers

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,0 +1,30 @@
+name: Ruff Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Ruff
+        run: |
+          python -m pip install --upgrade pip
+          pip install "ruff>=0.11.7"
+
+      - name: Run Ruff
+        run: ruff check .


### PR DESCRIPTION
## Summary
- restrict the Ruff lint workflow to only run on pushes to main and newly opened pull requests

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_69017855f258832b8324397a4cb22eb2